### PR TITLE
adding dtype-decimal feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "dog"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -762,6 +775,15 @@ dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.9",
  "zlib-rs",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -977,6 +999,16 @@ dependencies = [
  "num-traits",
  "serde",
  "zerocopy",
+]
+
+[[package]]
+name = "halfbrown"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
 ]
 
 [[package]]
@@ -1857,6 +1889,7 @@ dependencies = [
  "polars-compute",
  "polars-core",
  "polars-error",
+ "polars-json",
  "polars-parquet",
  "polars-schema",
  "polars-time",
@@ -1868,6 +1901,27 @@ dependencies = [
  "serde_json",
  "simdutf8",
  "tokio",
+ "zmij",
+]
+
+[[package]]
+name = "polars-json"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55581d4cc8f4122cae92d12aec997e6713ac483871391a7db09501604007be4b"
+dependencies = [
+ "chrono",
+ "fallible-streaming-iterator",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "itoa",
+ "num-traits",
+ "polars-arrow",
+ "polars-compute",
+ "polars-error",
+ "polars-utils",
+ "simd-json",
+ "streaming-iterator",
  "zmij",
 ]
 
@@ -2429,6 +2483,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2771,6 +2845,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd-json"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4255126f310d2ba20048db6321c81ab376f6a6735608bf11f0785c41f01f64e3"
+dependencies = [
+ "ahash",
+ "halfbrown",
+ "once_cell",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
+]
 
 [[package]]
 name = "simdutf8"
@@ -3214,6 +3304,18 @@ dependencies = [
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "value-trait"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e80f0c733af0720a501b3905d22e2f97662d8eacfe082a75ed7ffb5ab08cb59"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive"] }
 colored = "3.1.1"
 fitsio-pure = { version = "0.11.0", features = ["compat"] }
-polars = { version = "0.53.0", features = ["parquet", "csv", "dtype-i16", "lazy"] }
+polars = { version = "0.53.0", features = ["parquet", "csv", "dtype-i16", "lazy", "dtype-decimal"] }
 polars-buffer = "0.53.0"
 rayon = "1.12.0"
 thiserror = "2.0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dog"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ The first step is to determine what architecture your system is running. This ca
 For Mac-OS the binaries can be downloaded for newer macs running m-chips (arm64)
 **Installing dog is very easy**
 ```
-curl -L -o dog https://github.com/trystanscottlambert/dog/releases/download/v0.4.1/dog-aarch64-apple-darwin
+curl -L -o dog https://github.com/trystanscottlambert/dog/releases/download/v0.4.2/dog-aarch64-apple-darwin
 chmod +x dog-aarch64-apple-darwin
 sudo mv dog-aarch64-apple-darwin /usr/local/bin/dog
 ```
 
 For older models then:
 ```
-curl -L -o dog https://github.com/trystanscottlambert/dog/releases/download/v0.4.1/dog-x86_64-apple-darwin
+curl -L -o dog https://github.com/trystanscottlambert/dog/releases/download/v0.4.2/dog-x86_64-apple-darwin
 chmod +x dog-x86_64-apple-darwin
 sudo mv dog-x86_64-apple-darwin /usr/local/bin/dog
 ```
@@ -42,7 +42,7 @@ should work.
 ### Linux
 Ubuntu/debian flavors of linux should work with:
 ```
-curl -L -o dog https://github.com/trystanscottlambert/dog/releases/download/v0.4.1/dog-x86_64-unknown-linux-gnu
+curl -L -o dog https://github.com/trystanscottlambert/dog/releases/download/v0.4.2/dog-x86_64-unknown-linux-gnu
 chmod +x dog-x86_64-unknown-linux-gnu
 sudo mv dog-x86_64-unknown-linux-gnu /usr/local/bin/dog
 ```


### PR DESCRIPTION
Closes #38 

This adds decimal support by including the `dtype-decimal` feature in polars. 

No actual change in the code is required.