### PR TITLE
45 insert maml metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,6 @@ dependencies = [
  "polars",
  "polars-buffer",
  "rayon",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,7 @@ dependencies = [
  "polars",
  "polars-buffer",
  "rayon",
+ "serde_yaml",
  "thiserror",
 ]
 
@@ -2893,6 +2894,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3369,6 +3383,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,6 @@ dependencies = [
  "polars",
  "polars-buffer",
  "rayon",
- "serde_yaml",
  "thiserror",
 ]
 
@@ -2894,19 +2893,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3383,12 +3369,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,4 @@ fitsio-pure = { version = "0.11.0", features = ["compat"] }
 polars = { version = "0.54.4", features = ["parquet", "csv", "dtype-i16", "lazy", "dtype-decimal", "strings"] }
 polars-buffer = "0.54.4"
 rayon = "1.12.0"
-serde_yaml = "0.9.34"
 thiserror = "2.0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,3 @@ fitsio-pure = { version = "0.11.0", features = ["compat"] }
 polars = { version = "0.54.4", features = ["parquet", "csv", "dtype-i16", "lazy", "dtype-decimal", "strings"] }
 polars-buffer = "0.54.4"
 rayon = "1.12.0"
-thiserror = "2.0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ fitsio-pure = { version = "0.11.0", features = ["compat"] }
 polars = { version = "0.54.4", features = ["parquet", "csv", "dtype-i16", "lazy", "dtype-decimal", "strings"] }
 polars-buffer = "0.54.4"
 rayon = "1.12.0"
+serde_yaml = "0.9.34"
 thiserror = "2.0.18"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -117,6 +117,7 @@ pub fn build_cli() -> Command {
                     "peak",
                     "stats",
                     "maml",
+                    "schema",
                 ])
                 .multiple(false),
         )

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 // cli manager
 
-use clap::{Arg, ArgAction, Command};
+use clap::{Arg, ArgAction, ArgGroup, Command};
 
 pub fn build_cli() -> Command {
     Command::new("dog")
@@ -47,16 +47,14 @@ pub fn build_cli() -> Command {
                 .short('t')
                 .long("tail")
                 .help("Prints the bottom ten rows of data.")
-                .action(ArgAction::SetTrue)
-                .conflicts_with("head"),
+                .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("head")
                 .short('H')
                 .long("head")
                 .help("Prints the top ten rows of data and the column names.")
-                .action(ArgAction::SetTrue)
-                .conflicts_with("tail"),
+                .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("schema")
@@ -70,6 +68,7 @@ pub fn build_cli() -> Command {
                 .long("columns")
                 .help("Prints only the selected columns by name.")
                 .num_args(1)
+                .conflicts_with_all(["convert", "insert-maml"])
                 .value_delimiter(','),
         )
         .arg(
@@ -104,5 +103,21 @@ pub fn build_cli() -> Command {
                 .long("convert")
                 .help("Attempts to convert csv and fits files into a parquet if it can.")
                 .action(ArgAction::SetTrue),
+        )
+        .group(
+            ArgGroup::new("mode")
+                .args([
+                    "names",
+                    "data",
+                    "tail",
+                    "head",
+                    "convert",
+                    "insert-maml",
+                    "summary",
+                    "peak",
+                    "stats",
+                    "maml",
+                ])
+                .multiple(false),
         )
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,7 +68,7 @@ pub fn build_cli() -> Command {
                 .long("columns")
                 .help("Prints only the selected columns by name.")
                 .num_args(1)
-                .conflicts_with_all(["convert", "insert-maml"])
+                .conflicts_with_all(["convert", "insert-maml", "schema", "maml"])
                 .value_delimiter(','),
         )
         .arg(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,21 @@ pub fn build_cli() -> Command {
                 .conflicts_with("names"),
         )
         .arg(
+            Arg::new("insert-maml")
+                .long("insert-maml")
+                .help("Inserts MAML metadata from the given .maml file into the parquet file.")
+                .num_args(1)
+                .value_name("MAML_FILE"),
+        )
+        .arg(
+            Arg::new("force")
+                .short('F')
+                .long("force")
+                .help("Overwrite existing MAML metadata if it is already present.")
+                .action(ArgAction::SetTrue)
+                .requires("insert-maml"),
+        )
+        .arg(
             Arg::new("tail")
                 .short('t')
                 .long("tail")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,7 +32,7 @@ pub fn build_cli() -> Command {
                 .long("insert-maml")
                 .help("Inserts MAML metadata from the given .maml file into the parquet file.")
                 .num_args(1)
-                .value_name("MAML_FILE"),
+                .value_name("maml_file"),
         )
         .arg(
             Arg::new("force")

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,8 @@ mod write;
 use std::path::PathBuf;
 
 use crate::printer::*;
-use crate::reader::{read_file, which_file, FileType};
-use crate::write::write_parquet;
+use crate::reader::{read_file, read_yaml, which_file, FileType};
+use crate::write::{write_parquet, write_waves_metadata};
 use anyhow::Result;
 use clap::ArgMatches;
 use polars::prelude::*;
@@ -50,6 +50,16 @@ fn handle_arguments(matches: ArgMatches) -> Result<()> {
             FileType::Parquet => panic!("File is already a parquet!"),
         };
         write_parquet(lazy_frame, &outfile).unwrap();
+    } else if let Some(maml_file) = matches.get_one::<String>("insert-maml") {
+        let maml = read_yaml(PathBuf::from(maml_file))?;
+        let force = matches.get_flag("force");
+        if !force && check_for_maml_metadata(&file_path)? {
+            anyhow::bail!(
+                "{} already contains MAML metadata; pass -F to overwrite.",
+                file_path.display()
+            );
+        }
+        write_waves_metadata(lazy_frame, &file_path, maml)?;
     } else {
         print_only_data(lazy_frame, true)?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,8 @@ fn handle_arguments(matches: ArgMatches) -> Result<()> {
         let force = matches.get_flag("force");
         if !force && check_for_maml_metadata(&file_path)? {
             anyhow::bail!(
-                "{} already contains MAML metadata; pass -F to overwrite.",
+                "{} already contains MAML metadata; pass -F to overwrite; run `dog -w {}` to view.",
+                file_path.display(),
                 file_path.display()
             );
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,15 @@
 mod cli;
+mod maml_footer;
 mod printer;
 mod reader;
 mod write;
 
 use std::path::PathBuf;
 
+use crate::maml_footer::write_waves_metadata;
 use crate::printer::*;
 use crate::reader::{read_file, read_yaml, which_file, FileType};
-use crate::write::{write_parquet, write_waves_metadata};
+use crate::write::write_parquet;
 use anyhow::Result;
 use clap::ArgMatches;
 use polars::prelude::*;
@@ -17,6 +19,19 @@ fn handle_arguments(matches: ArgMatches) -> Result<()> {
         .get_one::<String>("file")
         .expect("File argument missing");
     let file_path = PathBuf::from(file);
+
+    if let Some(maml_file) = matches.get_one::<String>("insert-maml") {
+        let maml = read_yaml(PathBuf::from(maml_file))?;
+        let force = matches.get_flag("force");
+        if !force && check_for_maml_metadata(&file_path)? {
+            anyhow::bail!(
+                "{} already contains MAML metadata; pass -F to overwrite.",
+                file_path.display()
+            );
+        }
+        write_waves_metadata(&file_path, &maml)?;
+        return Ok(());
+    }
     let mut lazy_frame = read_file(file_path.clone())?;
 
     // Optional column filtering BEFORE any printing
@@ -50,16 +65,6 @@ fn handle_arguments(matches: ArgMatches) -> Result<()> {
             FileType::Parquet => panic!("File is already a parquet!"),
         };
         write_parquet(lazy_frame, &outfile).unwrap();
-    } else if let Some(maml_file) = matches.get_one::<String>("insert-maml") {
-        let maml = read_yaml(PathBuf::from(maml_file))?;
-        let force = matches.get_flag("force");
-        if !force && check_for_maml_metadata(&file_path)? {
-            anyhow::bail!(
-                "{} already contains MAML metadata; pass -F to overwrite.",
-                file_path.display()
-            );
-        }
-        write_waves_metadata(lazy_frame, &file_path, maml)?;
     } else {
         print_only_data(lazy_frame, true)?;
     }

--- a/src/maml_footer.rs
+++ b/src/maml_footer.rs
@@ -1,0 +1,332 @@
+//! In-place editing of the Parquet footer's `key_value_metadata`, inspired by
+//! how nanoparquet's `append_parquet` works: read the footer, leave every byte
+//! of row-group data untouched, and rewrite only the tail of the file.
+//!
+//! `write_waves_metadata` upserts a single `maml` key: it drops any existing
+//! `maml` entry and appends the new one, preserving all other keys (including
+//! `ARROW:schema`). Peak memory is the footer size; no data is decoded or
+//! recompressed, and no second copy of the file is made.
+//!
+//! Limitation: standard, unencrypted footer only (magic `PAR1`).
+
+use anyhow::{anyhow, bail, Result};
+use std::fs::OpenOptions;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+
+const MAGIC: &[u8; 4] = b"PAR1";
+
+// Thrift compact-protocol type ids.
+const T_STOP: u8 = 0;
+const T_BOOL_TRUE: u8 = 1;
+const T_BOOL_FALSE: u8 = 2;
+const T_I8: u8 = 3;
+const T_I16: u8 = 4;
+const T_I32: u8 = 5;
+const T_I64: u8 = 6;
+const T_DOUBLE: u8 = 7;
+const T_BINARY: u8 = 8;
+const T_LIST: u8 = 9;
+const T_SET: u8 = 10;
+const T_MAP: u8 = 11;
+const T_STRUCT: u8 = 12;
+
+const KEY_VALUE_FIELD_ID: i64 = 5; // FileMetaData.key_value_metadata
+
+/// Insert/replace the `maml` key in `output_path`'s footer, in place.
+///
+/// The `-F` / existence handling lives in the caller; this always upserts
+/// (drops any existing `maml`, appends the new value), so calling it with
+/// `force` already decided is correct in every case.
+pub fn write_waves_metadata(output_path: &PathBuf, maml: &str) -> Result<()> {
+    // Open read+write WITHOUT truncating.
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(output_path)?;
+    let file_len = file.metadata()?.len();
+    if file_len < 12 {
+        bail!(
+            "{}: not a parquet file (smaller than 12 bytes)",
+            output_path.display()
+        );
+    }
+
+    // Last 8 bytes: [metadata_len u32 LE][PAR1].
+    let mut tail = [0u8; 8];
+    file.seek(SeekFrom::End(-8))?;
+    file.read_exact(&mut tail)?;
+    if tail[4..] != MAGIC[..] {
+        bail!(
+            "{}: missing PAR1 footer magic (encrypted or non-parquet?)",
+            output_path.display()
+        );
+    }
+    let metadata_len = u32::from_le_bytes(tail[..4].try_into().unwrap()) as u64;
+    let footer_start = file_len
+        .checked_sub(8 + metadata_len)
+        .ok_or_else(|| anyhow!("declared footer length exceeds file size"))?;
+
+    // Read only the FileMetaData blob (a few KB), then build the new one.
+    let mut blob = vec![0u8; metadata_len as usize];
+    file.seek(SeekFrom::Start(footer_start))?;
+    file.read_exact(&mut blob)?;
+    let new_blob = upsert_kv(&blob, "maml", maml)?;
+
+    // Overwrite only the tail, starting exactly where the old footer began.
+    // All bytes before footer_start (the data + page indexes) are untouched.
+    file.seek(SeekFrom::Start(footer_start))?;
+    file.write_all(&new_blob)?;
+    file.write_all(&(new_blob.len() as u32).to_le_bytes())?;
+    file.write_all(MAGIC)?;
+
+    // The new footer may be shorter or longer than the old one; set exact length.
+    file.set_len(footer_start + new_blob.len() as u64 + 8)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+/// Walk the top-level `FileMetaData` fields, upsert `key`=`value` into the
+/// key/value metadata list, and return `new_footer_blob`.
+fn upsert_kv(blob: &[u8], key: &str, value: &str) -> Result<Vec<u8>> {
+    let mut pos = 0usize;
+    let mut last_id = 0i64;
+
+    loop {
+        let field_start = pos;
+        let (type_id, field_id, is_stop) = read_field_header(blob, &mut pos, &mut last_id)?;
+
+        if is_stop {
+            // No field 5: insert a fresh one right before STOP.
+            let field = encode_kv_field(&[(key.to_string(), Some(value.to_string()))]);
+            let mut out = Vec::with_capacity(blob.len() + field.len());
+            out.extend_from_slice(&blob[..field_start]); // everything before STOP
+            out.extend_from_slice(&field);
+            out.extend_from_slice(&blob[field_start..]); // the STOP byte
+            return Ok(out);
+        }
+
+        if field_id == KEY_VALUE_FIELD_ID {
+            if type_id != T_LIST {
+                bail!("key_value_metadata is not a list (thrift type {type_id})");
+            }
+            let (elem_type, count) = read_collection_header(blob, &mut pos)?;
+            if count > 0 && elem_type != T_STRUCT {
+                bail!("key_value_metadata elements are not structs");
+            }
+            let mut pairs = Vec::with_capacity(count as usize + 1);
+            for _ in 0..count {
+                pairs.push(parse_key_value(blob, &mut pos)?);
+            }
+            let list_end = pos; // first byte after the list = next field header
+
+            pairs.retain(|(k, _)| k != key);
+            pairs.push((key.to_string(), Some(value.to_string())));
+
+            let field = encode_kv_field(&pairs);
+            let mut out = Vec::with_capacity(blob.len() + field.len());
+            out.extend_from_slice(&blob[..field_start]); // fields before field 5
+            out.extend_from_slice(&field); // freshly encoded field 5 (long-form header)
+            out.extend_from_slice(&blob[list_end..]); // fields after field 5 + STOP
+            return Ok(out);
+        }
+
+        skip_value(blob, &mut pos, type_id)?;
+    }
+}
+
+/// Encode a complete `FileMetaData` field 5 from pairs. Uses the long-form
+/// field header (absolute id 5), which keeps neighbouring fields' delta
+/// encoding valid regardless of where this lands.
+fn encode_kv_field(pairs: &[(String, Option<String>)]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.push((0 << 4) | T_LIST); // delta 0 (long form) + type LIST
+    write_uvarint(&mut out, zigzag(KEY_VALUE_FIELD_ID));
+    write_collection_header(&mut out, T_STRUCT, pairs.len() as u64);
+    for (k, v) in pairs {
+        out.push((1 << 4) | T_BINARY); // field 1: key
+        write_uvarint(&mut out, k.len() as u64);
+        out.extend_from_slice(k.as_bytes());
+        if let Some(v) = v {
+            out.push((1 << 4) | T_BINARY); // field 2: value
+            write_uvarint(&mut out, v.len() as u64);
+            out.extend_from_slice(v.as_bytes());
+        }
+        out.push(T_STOP);
+    }
+    out
+}
+
+fn parse_key_value(buf: &[u8], pos: &mut usize) -> Result<(String, Option<String>)> {
+    let mut last_id = 0i64;
+    let mut key: Option<String> = None;
+    let mut value: Option<String> = None;
+    loop {
+        let (type_id, field_id, is_stop) = read_field_header(buf, pos, &mut last_id)?;
+        if is_stop {
+            break;
+        }
+        if type_id == T_BINARY {
+            let s = read_binary_str(buf, pos)?;
+            match field_id {
+                1 => key = Some(s),
+                2 => value = Some(s),
+                _ => {}
+            }
+        } else {
+            skip_value(buf, pos, type_id)?;
+        }
+    }
+    Ok((
+        key.ok_or_else(|| anyhow!("KeyValue missing required key"))?,
+        value,
+    ))
+}
+
+// ---- compact-protocol primitives ----
+
+fn read_field_header(buf: &[u8], pos: &mut usize, last_id: &mut i64) -> Result<(u8, i64, bool)> {
+    let b = *buf
+        .get(*pos)
+        .ok_or_else(|| anyhow!("field header out of bounds"))?;
+    *pos += 1;
+    if b == 0 {
+        return Ok((T_STOP, 0, true));
+    }
+    let type_id = b & 0x0F;
+    let delta = (b >> 4) as i64;
+    let field_id = if delta == 0 {
+        unzigzag(read_uvarint(buf, pos)?) // long form
+    } else {
+        *last_id + delta
+    };
+    *last_id = field_id;
+    Ok((type_id, field_id, false))
+}
+
+fn read_collection_header(buf: &[u8], pos: &mut usize) -> Result<(u8, u64)> {
+    let header = *buf
+        .get(*pos)
+        .ok_or_else(|| anyhow!("collection header out of bounds"))?;
+    *pos += 1;
+    let elem_type = header & 0x0F;
+    let mut count = (header >> 4) as u64;
+    if count == 15 {
+        count = read_uvarint(buf, pos)?;
+    }
+    Ok((elem_type, count))
+}
+
+fn write_collection_header(out: &mut Vec<u8>, elem_type: u8, count: u64) {
+    if count < 15 {
+        out.push(((count as u8) << 4) | elem_type);
+    } else {
+        out.push(0xF0 | elem_type);
+        write_uvarint(out, count);
+    }
+}
+
+fn skip_value(buf: &[u8], pos: &mut usize, type_id: u8) -> Result<()> {
+    match type_id {
+        T_BOOL_TRUE | T_BOOL_FALSE => {}
+        T_I8 => *pos += 1,
+        T_I16 | T_I32 | T_I64 => {
+            read_uvarint(buf, pos)?;
+        }
+        T_DOUBLE => *pos += 8,
+        T_BINARY => {
+            let len = read_uvarint(buf, pos)? as usize;
+            *pos += len;
+        }
+        T_LIST | T_SET => {
+            let (elem_type, count) = read_collection_header(buf, pos)?;
+            for _ in 0..count {
+                skip_value(buf, pos, elem_type)?;
+            }
+        }
+        T_MAP => {
+            let count = read_uvarint(buf, pos)?;
+            if count > 0 {
+                let kv = *buf
+                    .get(*pos)
+                    .ok_or_else(|| anyhow!("map header out of bounds"))?;
+                *pos += 1;
+                let (kt, vt) = (kv >> 4, kv & 0x0F);
+                for _ in 0..count {
+                    skip_value(buf, pos, kt)?;
+                    skip_value(buf, pos, vt)?;
+                }
+            }
+        }
+        T_STRUCT => {
+            let mut last_id = 0i64;
+            loop {
+                let (t, _id, stop) = read_field_header(buf, pos, &mut last_id)?;
+                if stop {
+                    break;
+                }
+                skip_value(buf, pos, t)?;
+            }
+        }
+        other => bail!("unknown thrift type id {other}"),
+    }
+    if *pos > buf.len() {
+        bail!("overran footer while parsing");
+    }
+    Ok(())
+}
+
+fn read_binary_str(buf: &[u8], pos: &mut usize) -> Result<String> {
+    let len = read_uvarint(buf, pos)? as usize;
+    let end = pos
+        .checked_add(len)
+        .ok_or_else(|| anyhow!("binary length overflow"))?;
+    let bytes = buf
+        .get(*pos..end)
+        .ok_or_else(|| anyhow!("binary out of bounds"))?;
+    let s = String::from_utf8(bytes.to_vec())?;
+    *pos = end;
+    Ok(s)
+}
+
+fn read_uvarint(buf: &[u8], pos: &mut usize) -> Result<u64> {
+    let mut result: u64 = 0;
+    let mut shift = 0u32;
+    loop {
+        let byte = *buf
+            .get(*pos)
+            .ok_or_else(|| anyhow!("varint out of bounds"))?;
+        *pos += 1;
+        result |= ((byte & 0x7F) as u64) << shift;
+        if byte & 0x80 == 0 {
+            break;
+        }
+        shift += 7;
+        if shift >= 64 {
+            bail!("varint too long");
+        }
+    }
+    Ok(result)
+}
+
+fn write_uvarint(out: &mut Vec<u8>, mut v: u64) {
+    loop {
+        let mut byte = (v & 0x7F) as u8;
+        v >>= 7;
+        if v != 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        if v == 0 {
+            break;
+        }
+    }
+}
+
+fn zigzag(v: i64) -> u64 {
+    ((v << 1) ^ (v >> 63)) as u64
+}
+
+fn unzigzag(v: u64) -> i64 {
+    ((v >> 1) as i64) ^ -((v & 1) as i64)
+}

--- a/src/maml_footer.rs
+++ b/src/maml_footer.rs
@@ -34,12 +34,7 @@ const T_STRUCT: u8 = 12;
 const KEY_VALUE_FIELD_ID: i64 = 5; // FileMetaData.key_value_metadata
 
 /// Insert/replace the `maml` key in `output_path`'s footer, in place.
-///
-/// The `-F` / existence handling lives in the caller; this always upserts
-/// (drops any existing `maml`, appends the new value), so calling it with
-/// `force` already decided is correct in every case.
 pub fn write_waves_metadata(output_path: &PathBuf, maml: &str) -> Result<()> {
-    // Open read+write WITHOUT truncating.
     let mut file = OpenOptions::new()
         .read(true)
         .write(true)
@@ -74,7 +69,6 @@ pub fn write_waves_metadata(output_path: &PathBuf, maml: &str) -> Result<()> {
     let new_blob = upsert_kv(&blob, "maml", maml)?;
 
     // Overwrite only the tail, starting exactly where the old footer began.
-    // All bytes before footer_start (the data + page indexes) are untouched.
     file.seek(SeekFrom::Start(footer_start))?;
     file.write_all(&new_blob)?;
     file.write_all(&(new_blob.len() as u32).to_le_bytes())?;
@@ -87,7 +81,7 @@ pub fn write_waves_metadata(output_path: &PathBuf, maml: &str) -> Result<()> {
 }
 
 /// Walk the top-level `FileMetaData` fields, upsert `key`=`value` into the
-/// key/value metadata list, and return `new_footer_blob`.
+/// key/value metadata list, and return `(new_footer_blob, key_already_existed)`.
 fn upsert_kv(blob: &[u8], key: &str, value: &str) -> Result<Vec<u8>> {
     let mut pos = 0usize;
     let mut last_id = 0i64;
@@ -137,9 +131,11 @@ fn upsert_kv(blob: &[u8], key: &str, value: &str) -> Result<Vec<u8>> {
 
 /// Encode a complete `FileMetaData` field 5 from pairs. Uses the long-form
 /// field header (absolute id 5), which keeps neighbouring fields' delta
-/// encoding valid regardless of where this lands.
+/// encoding valid regardless of where this lands. This means we shouldn't
+/// corrupt the delta encoding.
 fn encode_kv_field(pairs: &[(String, Option<String>)]) -> Vec<u8> {
     let mut out = Vec::new();
+    #[allow(clippy::identity_op)] // This (0<<4) has no effect but we're showing intent here.
     out.push((0 << 4) | T_LIST); // delta 0 (long form) + type LIST
     write_uvarint(&mut out, zigzag(KEY_VALUE_FIELD_ID));
     write_collection_header(&mut out, T_STRUCT, pairs.len() as u64);
@@ -183,8 +179,9 @@ fn parse_key_value(buf: &[u8], pos: &mut usize) -> Result<(String, Option<String
     ))
 }
 
-// ---- compact-protocol primitives ----
+// following are just the keywords that are used in the thrift protocol. Encoding and decoding.
 
+/// Reads the raw array of bytes into the type_id, field_id, and weather it is a stop command.
 fn read_field_header(buf: &[u8], pos: &mut usize, last_id: &mut i64) -> Result<(u8, i64, bool)> {
     let b = *buf
         .get(*pos)
@@ -204,6 +201,7 @@ fn read_field_header(buf: &[u8], pos: &mut usize, last_id: &mut i64) -> Result<(
     Ok((type_id, field_id, false))
 }
 
+// reads the raw array of bytes and converts this into the element type and the number of elements.
 fn read_collection_header(buf: &[u8], pos: &mut usize) -> Result<(u8, u64)> {
     let header = *buf
         .get(*pos)
@@ -217,6 +215,7 @@ fn read_collection_header(buf: &[u8], pos: &mut usize) -> Result<(u8, u64)> {
     Ok((elem_type, count))
 }
 
+// converts the element type and the count into bytes and adds them to the `out` bytes array.
 fn write_collection_header(out: &mut Vec<u8>, elem_type: u8, count: u64) {
     if count < 15 {
         out.push(((count as u8) << 4) | elem_type);
@@ -226,6 +225,7 @@ fn write_collection_header(out: &mut Vec<u8>, elem_type: u8, count: u64) {
     }
 }
 
+// Updates the pos cursor by skipping over the different types we don't care about.
 fn skip_value(buf: &[u8], pos: &mut usize, type_id: u8) -> Result<()> {
     match type_id {
         T_BOOL_TRUE | T_BOOL_FALSE => {}
@@ -323,10 +323,12 @@ fn write_uvarint(out: &mut Vec<u8>, mut v: u64) {
     }
 }
 
+// convert signed integers into unsigned integers via zigzag encoding
 fn zigzag(v: i64) -> u64 {
     ((v << 1) ^ (v >> 63)) as u64
 }
 
+// convert zigzag encoded unsigned integers to signed integers
 fn unzigzag(v: u64) -> i64 {
     ((v >> 1) as i64) ^ -((v & 1) as i64)
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -23,7 +23,18 @@ pub fn print_schema(lazy_frame: LazyFrame) -> Result<()> {
     println!("{:#?}", schema);
     Ok(())
 }
-
+pub fn check_for_maml_metadata(file_name: &PathBuf) -> Result<bool> {
+    let file = File::open(file_name)?;
+    let mut reader = ParquetReader::new(file);
+    if let Some(kv_metadata) = reader.get_metadata()?.key_value_metadata() {
+        for kv in kv_metadata {
+            if kv.key == "maml" {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
 pub fn print_waves_metadata(file_name: &PathBuf) -> Result<()> {
     let file = File::open(file_name)?;
     let mut reader = ParquetReader::new(file);

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -203,3 +203,10 @@ pub fn read_file(file_name: PathBuf) -> Result<LazyFrame> {
         FileType::Fits => Ok(read_fits_file(&file_name).unwrap()),
     }
 }
+
+pub fn read_yaml(file_name: PathBuf) -> Result<String> {
+    let reader = std::fs::File::open(file_name)?;
+    let thing: String = serde_yaml::from_reader(reader)?;
+    Ok(thing)
+
+}

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -205,8 +205,5 @@ pub fn read_file(file_name: PathBuf) -> Result<LazyFrame> {
 }
 
 pub fn read_yaml(file_name: PathBuf) -> Result<String> {
-    let reader = std::fs::File::open(file_name)?;
-    let thing: String = serde_yaml::from_reader(reader)?;
-    Ok(thing)
-
+    Ok(std::fs::read_to_string(file_name)?)
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -10,3 +10,13 @@ pub fn write_parquet(lazy_frame: LazyFrame, output_path: &PathBuf) -> Result<()>
 
     Ok(())
 }
+
+pub fn write_waves_metadata(file_name: &PathBuf, df: &mut DataFrame, maml: &str) -> Result<()> {
+    let kv = KeyValueMetadata::from_static(vec![("maml".to_string(), maml.to_string())]);
+
+    let file = File::create(file_name)?;
+    ParquetWriter::new(file)
+        .with_key_value_metadata(Some(kv))
+        .finish(df)?;
+    Ok(())
+}

--- a/src/write.rs
+++ b/src/write.rs
@@ -14,7 +14,7 @@ pub fn write_parquet(lazy_frame: LazyFrame, output_path: &PathBuf) -> Result<()>
 pub fn write_waves_metadata(
     lazy_frame: LazyFrame,
     output_path: &PathBuf,
-    maml: &str,
+    maml: String,
 ) -> Result<()> {
     let lf = lazy_frame.clone();
     let kv = KeyValueMetadata::from_static(vec![("maml".to_string(), maml.to_string())]);

--- a/src/write.rs
+++ b/src/write.rs
@@ -10,18 +10,3 @@ pub fn write_parquet(lazy_frame: LazyFrame, output_path: &PathBuf) -> Result<()>
 
     Ok(())
 }
-
-pub fn write_waves_metadata(
-    lazy_frame: LazyFrame,
-    output_path: &PathBuf,
-    maml: String,
-) -> Result<()> {
-    let mut df = lazy_frame.clone().collect()?;
-    let kv = KeyValueMetadata::from_static(vec![("maml".to_string(), maml.to_string())]);
-
-    let file = File::create(output_path)?;
-    ParquetWriter::new(file)
-        .with_key_value_metadata(Some(kv))
-        .finish(&mut df)?;
-    Ok(())
-}

--- a/src/write.rs
+++ b/src/write.rs
@@ -11,12 +11,17 @@ pub fn write_parquet(lazy_frame: LazyFrame, output_path: &PathBuf) -> Result<()>
     Ok(())
 }
 
-pub fn write_waves_metadata(file_name: &PathBuf, df: &mut DataFrame, maml: &str) -> Result<()> {
+pub fn write_waves_metadata(
+    lazy_frame: LazyFrame,
+    output_path: &PathBuf,
+    maml: &str,
+) -> Result<()> {
+    let lf = lazy_frame.clone();
     let kv = KeyValueMetadata::from_static(vec![("maml".to_string(), maml.to_string())]);
 
-    let file = File::create(file_name)?;
+    let file = File::create(output_path)?;
     ParquetWriter::new(file)
         .with_key_value_metadata(Some(kv))
-        .finish(df)?;
+        .finish(&mut lf.collect()?)?;
     Ok(())
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -16,12 +16,12 @@ pub fn write_waves_metadata(
     output_path: &PathBuf,
     maml: String,
 ) -> Result<()> {
-    let lf = lazy_frame.clone();
+    let mut df = lazy_frame.clone().collect()?;
     let kv = KeyValueMetadata::from_static(vec![("maml".to_string(), maml.to_string())]);
 
     let file = File::create(output_path)?;
     ParquetWriter::new(file)
         .with_key_value_metadata(Some(kv))
-        .finish(&mut lf.collect()?)?;
+        .finish(&mut df)?;
     Ok(())
 }


### PR DESCRIPTION
closes #45 

This adds the functionality of putting maml files into the maml header of a parquet file. 