### PR TITLE
Return an error instead of panicking on unsupported FITS column types

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -138,7 +138,7 @@ pub fn read_fits_file(path: &PathBuf) -> Result<LazyFrame> {
     // Flatten the results and collect all columns
     let mut all_columns = Vec::new();
     for result in results {
-        let cols = result.unwrap();
+        let cols = result.map_err(|e| anyhow!("{e}"))?;
         all_columns.extend(cols);
     }
     
@@ -200,6 +200,6 @@ pub fn read_file(file_name: PathBuf) -> Result<LazyFrame> {
     match which_file(&file_name)? {
         FileType::Csv => Ok(read_csv_file(file_name)?),
         FileType::Parquet => Ok(read_parquet_file(file_name)?),
-        FileType::Fits => Ok(read_fits_file(&file_name).unwrap()),
+        FileType::Fits => Ok(read_fits_file(&file_name)?),
     }
 }


### PR DESCRIPTION
Converting a FITS file with a column type that isn't handled (for example `L` logical) aborted with a panic, because `read_file` unwrapped the result of `read_fits_file` and the inner column loop unwrapped each per-column result. Both now propagate the error like the CSV and Parquet arms already do, so the unsupported type is reported as `Error: Unsupported column type: L` with a non-zero exit instead of crashing.

This does not fully resolve #42 (the program still cannot handle logical and some other FITS types); it only turns the panic into a clear error for now.

Verified against a FITS file with a boolean column, and confirmed a numeric FITS file still reads correctly.
