### PR TITLE
50 perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "dog"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive"] }
 colored = "3.1.1"
 fitsio-pure = { version = "0.11.0", features = ["compat"] }
-polars = { version = "0.54.4", features = ["parquet", "csv", "dtype-i16", "lazy", "dtype-decimal", "strings"] }
+polars = { version = "0.54.4", features = ["parquet", "csv", "dtype-i16", "lazy", "dtype-decimal", "strings", "streaming"] }
 polars-buffer = "0.54.4"
 rayon = "1.12.0"

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -90,7 +90,7 @@ pub fn print_tail(lazy_frame: LazyFrame) -> Result<()> {
 
 pub fn print_head(lazy_frame: &mut LazyFrame) -> Result<()> {
     let head_frame = lazy_frame.clone();
-    let head = head_frame.slice(0, 10);
+    let head = head_frame.limit(10);
     print_column_names(lazy_frame)?;
     print_catlike(head)?;
     Ok(())
@@ -168,7 +168,7 @@ pub fn print_summary(lazy_frame: LazyFrame) -> Result<()> {
 
 pub fn peak(lazy_frame: LazyFrame) -> Result<()> {
     // prints out the polars data frame as 'peak'.
-    println!("{:?}", lazy_frame.limit(20).with_streaming(true).collect()?);
+    println!("{:?}", lazy_frame.limit(20).collect()?);
     Ok(())
 }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -172,58 +172,84 @@ pub fn peak(lazy_frame: LazyFrame) -> Result<()> {
     Ok(())
 }
 
-fn print_stat(column_name: &str, stat_name: &str, stat: DataFrame) -> Result<()> {
-    println!(
-        "{}: {}",
-        stat_name,
-        format!("{}", stat.column(column_name)?.get(0)?).green()
-    );
-    Ok(())
+fn fmt_cell(stats: &DataFrame, col: &str) -> Result<String> {
+    Ok(format!("{}", stats.column(col)?.get(0)?))
 }
 
+enum ColKind {
+    Numeric,
+    Str,
+    Other,
+}
+
+fn classify(dtype: &DataType) -> ColKind {
+    if dtype.is_primitive_numeric() {
+        ColKind::Numeric
+    } else if dtype.is_string() {
+        ColKind::Str
+    } else {
+        ColKind::Other // bool, dates, etc.
+    }
+}
 pub fn print_stats(lazy_frame: LazyFrame) -> Result<()> {
-    let means = lazy_frame
-        .clone()
-        .select([all().as_expr().mean()])
-        .collect()?;
-    let medians = lazy_frame
-        .clone()
-        .select([all().as_expr().median()])
-        .collect()?;
+    let mut lf = lazy_frame.clone();
+    let schema = lf.collect_schema()?;
 
-    let stds = lazy_frame
-        .clone()
-        .select([all().as_expr().std(1)])
-        .collect()?;
-    let null_counts = lazy_frame
-        .clone()
-        .select([all().as_expr().null_count()])
-        .collect()?;
-    let maxes = lazy_frame
-        .clone()
-        .select([all().as_expr().max()])
-        .collect()?;
-    let mins = lazy_frame
-        .clone()
-        .select([all().as_expr().min()])
-        .collect()?;
-    for name in lazy_frame.clone().collect_schema()?.iter_names() {
-        let mean = means.clone();
-        let median = medians.clone();
-        let null_count = null_counts.clone();
-        let max = maxes.clone();
-        let min = mins.clone();
-        let std = stds.clone();
-        println!("{}:", name.bold());
+    for (name, dtype) in schema.iter() {
+        let n = name.as_str();
+        let c = col(n);
+
+        // only this column's expressions
+        let mut exprs: Vec<Expr> = vec![c.clone().null_count().alias("nulls")];
+        match classify(dtype) {
+            ColKind::Numeric => {
+                exprs.push(c.clone().min().alias("min"));
+                exprs.push(c.clone().mean().alias("mean"));
+                exprs.push(c.clone().median().alias("median"));
+                exprs.push(c.clone().max().alias("max"));
+                exprs.push(c.std(1).alias("std"));
+            }
+            ColKind::Str => {
+                exprs.push(c.clone().min().alias("min"));
+                exprs.push(c.clone().max().alias("max"));
+                exprs.push(c.n_unique().alias("nunique"));
+            }
+            ColKind::Other => {
+                exprs.push(c.clone().min().alias("min"));
+                exprs.push(c.max().alias("max"));
+            }
+        }
+
+        // projection pushdown => scan reads only column `n`
+        let stats = lazy_frame
+            .clone()
+            .select(exprs)
+            .collect_with_engine(Engine::Streaming)?
+            .unwrap_single();
+
+        println!("{}:", n.bold());
         println!("---------------");
-        print_stat(name, "min", min)?;
-        print_stat(name, "mean", mean)?;
-        print_stat(name, "median", median)?;
-        print_stat(name, "max", max)?;
-        print_stat(name, "std", std)?;
-        print_stat(name, "null counts", null_count)?;
-
+        match classify(dtype) {
+            ColKind::Numeric => {
+                println!("min: {}", fmt_cell(&stats, "min")?.green());
+                println!("mean: {}", fmt_cell(&stats, "mean")?.green());
+                println!("median: {}", fmt_cell(&stats, "median")?.green());
+                println!("max: {}", fmt_cell(&stats, "max")?.green());
+                println!("std: {}", fmt_cell(&stats, "std")?.green());
+            }
+            ColKind::Str => {
+                println!("min: {}", fmt_cell(&stats, "min")?.green());
+                println!("max: {}", fmt_cell(&stats, "max")?.green());
+                println!("unique: {}", fmt_cell(&stats, "nunique")?.green());
+            }
+            ColKind::Other => {
+                println!("min: {}", fmt_cell(&stats, "min")?.green());
+                println!("max: {}", fmt_cell(&stats, "max")?.green());
+            }
+        }
+        println!("null counts: {}", fmt_cell(&stats, "nulls")?.green());
         println!();
+        // `stats` drops here; next column starts clean
     }
     Ok(())
 }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -168,7 +168,7 @@ pub fn print_summary(lazy_frame: LazyFrame) -> Result<()> {
 
 pub fn peak(lazy_frame: LazyFrame) -> Result<()> {
     // prints out the polars data frame as 'peak'.
-    println!("{:?}", lazy_frame.collect()?);
+    println!("{:?}", lazy_frame.limit(20).with_streaming(true).collect()?);
     Ok(())
 }
 


### PR DESCRIPTION
closes #50 #48 

Trying to limit the ram exploding on the collection of some lazyframes. Somethings like peak needen't read the whole thing in so that's easy. 

the only thing left is raw dog which will explode but I don't see how to get around this without chunking up the rows which maybe could be done asyncrously but not going to bother now. 

stats could also probably rely on a very basic set that is provided in the header somewhere but I'm not going to do that now since we only get null_counts, min, and max. 

Additionally stats now work for strings. 