### PR TITLE
54 filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,6 +705,8 @@ dependencies = [
  "fitsio-pure",
  "polars",
  "polars-buffer",
+ "predicate",
+ "predicates",
  "rayon",
  "tempfile",
 ]
@@ -1524,6 +1526,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "now"
@@ -2376,6 +2384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicate"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32f700c6541a5d7062a2b5b73eba1c0b64031f26f3357720bec60729b6a8e05"
+
+[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2383,7 +2397,10 @@ checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
 dependencies = [
  "anstyle",
  "difflib",
+ "float-cmp",
+ "normalize-line-endings",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,7 +705,6 @@ dependencies = [
  "fitsio-pure",
  "polars",
  "polars-buffer",
- "predicate",
  "predicates",
  "rayon",
  "tempfile",
@@ -2382,12 +2381,6 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
-
-[[package]]
-name = "predicate"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32f700c6541a5d7062a2b5b73eba1c0b64031f26f3357720bec60729b6a8e05"
 
 [[package]]
 name = "predicates"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,6 @@ rayon = "1.12.0"
 
 [dev-dependencies]
 assert_cmd = "2.2.2"
+predicate = "0.1.0"
+predicates = "3.1.4"
 tempfile = "3.27.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive"] }
 colored = "3.1.1"
 fitsio-pure = { version = "0.11.0", features = ["compat"] }
-polars = { version = "0.54.4", features = ["parquet", "csv", "dtype-i16", "lazy", "dtype-decimal", "strings", "streaming"] }
+polars = { version = "0.54.4", features = ["parquet", "csv", "dtype-i16", "lazy", "dtype-decimal", "strings", "streaming", "sql"] }
 polars-buffer = "0.54.4"
 rayon = "1.12.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,5 @@ rayon = "1.12.0"
 
 [dev-dependencies]
 assert_cmd = "2.2.2"
-predicate = "0.1.0"
 predicates = "3.1.4"
 tempfile = "3.27.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -104,6 +104,14 @@ pub fn build_cli() -> Command {
                 .help("Attempts to convert csv and fits files into a parquet if it can.")
                 .action(ArgAction::SetTrue),
         )
+        .arg(
+            Arg::new("filter")
+                .long("filter")
+                .short('f')
+                .help("Filter rows based on some selection.")
+                .num_args(1)
+                .conflicts_with_all(["convert", "insert-maml", "schema", "maml"]),
+        )
         .group(
             ArgGroup::new("mode")
                 .args([

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -108,8 +108,9 @@ pub fn build_cli() -> Command {
             Arg::new("filter")
                 .long("filter")
                 .short('f')
-                .help("Filter rows based on some selection.")
+                .help("Filter rows based on some selection. E.g. ra<10")
                 .num_args(1)
+                .value_name("sql-like row selection")
                 .conflicts_with_all(["convert", "insert-maml", "schema", "maml"]),
         )
         .group(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,6 +113,14 @@ pub fn build_cli() -> Command {
                 .value_name("sql-like row selection")
                 .conflicts_with_all(["convert", "insert-maml", "schema", "maml"]),
         )
+        .arg(
+            Arg::new("outfile")
+                .long("outfile")
+                .short('o')
+                .help("Save the current selection to the outfile")
+                .num_args(1)
+                .value_name("outfile-name"),
+        )
         .group(
             ArgGroup::new("mode")
                 .args([
@@ -127,6 +135,7 @@ pub fn build_cli() -> Command {
                     "stats",
                     "maml",
                     "schema",
+                    "outfile",
                 ])
                 .multiple(false),
         )

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,10 @@
+use anyhow::{anyhow, Result};
+use polars::prelude::*;
+use polars::sql::sql_expr;
+
+pub fn parse_selection_string(input: &str) -> Result<Expr> {
+    match sql_expr(input) {
+        Ok(expr) => Ok(expr),
+        _ => Err(anyhow!("Error parsing filter selection string.")),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,23 +37,36 @@ fn handle_arguments(matches: ArgMatches) -> Result<()> {
     }
 
     let mut lazy_frame = read_file(file_path.clone())?;
+    let mut columns_selected = false;
+    let mut rows_selected = false;
 
     // Optional column filtering BEFORE any printing
     if let Some(columns) = matches.get_many::<String>("columns") {
         let columns: Vec<Expr> = columns.map(col).collect();
         lazy_frame = lazy_frame.select(columns);
+        columns_selected = true;
     }
 
-    if let Some(filter_selection) = matches.get_many::<String>("filter") {
-        let argument: Vec<String> = filter_selection.map(|c| c.to_string()).collect();
-        let polars_expresion = match parse_selection_string(&argument[0]) {
+    if let Some(filter_selection) = matches.get_one::<String>("filter") {
+        let polars_expresion = match parse_selection_string(filter_selection) {
             Ok(expr) => expr,
             _ => anyhow::bail!(
                 "Error parsing the filter selection string: {}",
-                &argument[0]
+                filter_selection
             ),
         };
-        lazy_frame = lazy_frame.filter(polars_expresion)
+        lazy_frame = lazy_frame.filter(polars_expresion);
+        rows_selected = true;
+    }
+
+    if let Some(outfile_name) = matches.get_one::<String>("outfile") {
+        if rows_selected | columns_selected {
+            write_parquet(&lazy_frame, &PathBuf::from(outfile_name))?;
+
+            return Ok(());
+        } else {
+            anyhow::bail!("File not saved. No columns or rows have been selected.")
+        }
     }
 
     if *matches.get_one::<bool>("names").unwrap_or(&false) {
@@ -80,7 +93,7 @@ fn handle_arguments(matches: ArgMatches) -> Result<()> {
             FileType::Fits => PathBuf::from(file.replace(".fits", "_converted.parquet")),
             FileType::Parquet => panic!("File is already a parquet!"),
         };
-        write_parquet(lazy_frame, &outfile).unwrap();
+        write_parquet(&lazy_frame, &outfile).unwrap();
     } else {
         print_only_data(lazy_frame, true)?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod filter;
 mod maml_footer;
 mod printer;
 mod reader;
@@ -6,6 +7,7 @@ mod write;
 
 use std::path::PathBuf;
 
+use crate::filter::parse_selection_string;
 use crate::maml_footer::write_waves_metadata;
 use crate::printer::*;
 use crate::reader::{read_file, read_yaml, which_file, FileType};
@@ -33,12 +35,25 @@ fn handle_arguments(matches: ArgMatches) -> Result<()> {
         write_waves_metadata(&file_path, &maml)?;
         return Ok(());
     }
+
     let mut lazy_frame = read_file(file_path.clone())?;
 
     // Optional column filtering BEFORE any printing
     if let Some(columns) = matches.get_many::<String>("columns") {
         let columns: Vec<Expr> = columns.map(col).collect();
         lazy_frame = lazy_frame.select(columns);
+    }
+
+    if let Some(filter_selection) = matches.get_many::<String>("filter") {
+        let argument: Vec<String> = filter_selection.map(|c| c.to_string()).collect();
+        let polars_expresion = match parse_selection_string(&argument[0]) {
+            Ok(expr) => expr,
+            _ => anyhow::bail!(
+                "Error parsing the filter selection string: {}",
+                &argument[0]
+            ),
+        };
+        lazy_frame = lazy_frame.filter(polars_expresion)
     }
 
     if *matches.get_one::<bool>("names").unwrap_or(&false) {

--- a/src/write.rs
+++ b/src/write.rs
@@ -2,9 +2,9 @@ use anyhow::Result;
 use polars::prelude::*;
 use std::{fs::File, path::PathBuf};
 
-pub fn write_parquet(lazy_frame: LazyFrame, output_path: &PathBuf) -> Result<()> {
+pub fn write_parquet(lazy_frame: &LazyFrame, output_path: &PathBuf) -> Result<()> {
     let file = File::create(output_path)?;
-    let mut df = lazy_frame.collect().unwrap();
+    let mut df = lazy_frame.clone().collect().unwrap();
 
     ParquetWriter::new(file).finish(&mut df)?;
 

--- a/tests/filtering.rs
+++ b/tests/filtering.rs
@@ -1,0 +1,113 @@
+use assert_cmd::Command;
+use polars::{df, prelude::ParquetWriter};
+use predicates::prelude::*;
+use tempfile::{Builder, NamedTempFile};
+
+fn create_test_parquet() -> NamedTempFile {
+    let mut df = df! [
+        "ra" => [100., 200., 300.],
+        "dec" => [-20., 0., 20.],
+        "redshift" => [None, Some(1.), Some(0.2)],
+    ]
+    .unwrap();
+    let mut file = Builder::new().suffix(".parquet").tempfile().unwrap();
+    ParquetWriter::new(file.as_file_mut())
+        .finish(&mut df)
+        .unwrap();
+    file
+}
+
+fn run(file: &NamedTempFile, filter: &str) -> assert_cmd::assert::Assert {
+    Command::cargo_bin("dog")
+        .unwrap()
+        .arg("--filter")
+        .arg(filter)
+        .arg(file.path())
+        .assert()
+}
+
+#[test]
+fn test_simple_comparison() {
+    let f = create_test_parquet();
+    run(&f, "ra > 100")
+        .success()
+        .stdout(predicate::str::contains("200"))
+        .stdout(predicate::str::contains("300"))
+        .stdout(predicate::str::contains("100").not());
+}
+
+#[test]
+fn test_is_null() {
+    let f = create_test_parquet();
+    // only the ra=100 row has a null redshift
+    run(&f, "redshift IS NULL")
+        .success()
+        .stdout(predicate::str::contains("100"))
+        .stdout(predicate::str::contains("200").not());
+}
+
+#[test]
+fn test_is_not_null() {
+    let f = create_test_parquet();
+    run(&f, "redshift IS NOT NULL")
+        .success()
+        .stdout(predicate::str::contains("200"))
+        .stdout(predicate::str::contains("300"))
+        .stdout(predicate::str::contains("100").not());
+}
+
+#[test]
+fn test_null_excluded_by_comparison() {
+    let f = create_test_parquet();
+    // three-valued logic: the null row is neither < 0.5 nor >= 0.5
+    run(&f, "redshift < 0.5")
+        .success()
+        .stdout(predicate::str::contains("300"))
+        .stdout(predicate::str::contains("100").not());
+}
+
+#[test]
+fn test_and() {
+    let f = create_test_parquet();
+    run(&f, "ra > 100 AND dec < 20")
+        .success()
+        .stdout(predicate::str::contains("200"))
+        .stdout(predicate::str::contains("300").not());
+}
+
+#[test]
+fn test_or() {
+    let f = create_test_parquet();
+    run(&f, "ra = 100 OR redshift < 0.5")
+        .success()
+        .stdout(predicate::str::contains("100"))
+        .stdout(predicate::str::contains("300"))
+        .stdout(predicate::str::contains("200").not());
+}
+
+#[test]
+fn test_precedence_with_parens() {
+    let f = create_test_parquet();
+    run(&f, "(ra = 100 OR ra = 200) AND dec < 0")
+        .success()
+        .stdout(predicate::str::contains("100"))
+        .stdout(predicate::str::contains("200").not());
+}
+
+#[test]
+fn test_garbage_fails() {
+    let f = create_test_parquet();
+    run(&f, "this is not sql (((").failure();
+}
+
+#[test]
+fn test_unknown_column_fails() {
+    let f = create_test_parquet();
+    run(&f, "nonexistent > 5").failure();
+}
+
+#[test]
+fn test_dangling_operator_fails() {
+    let f = create_test_parquet();
+    run(&f, "ra >").failure();
+}


### PR DESCRIPTION
This MR allows users to pass a standard sql filter which can select the rows. 

So for example 
```
dog -c ra, dec -f 'zcos<0.2' example.parquet 
```

is now available. SQL here is basically just a WHERE command so that is quite simple for people to understand. 

We can also use IS NULL and IS NOT NULL and AND and OR and all that other good stuff. 