### PR TITLE
Adding handling multiple parquet files via glob patterns

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,7 @@ pub fn build_cli() -> Command {
             Arg::new("file")
                 .required(true)
                 .index(1) // this will always be the first positional argument
+                .num_args(1..)
                 .help("Input parquet file."),
         )
         .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,86 +17,93 @@ use clap::ArgMatches;
 use polars::prelude::*;
 
 fn handle_arguments(matches: ArgMatches) -> Result<()> {
-    let file = matches
-        .get_one::<String>("file")
+    let files = matches
+        .get_many::<String>("file")
         .expect("File argument missing");
-    let file_path = PathBuf::from(file);
 
-    if let Some(maml_file) = matches.get_one::<String>("insert-maml") {
-        let maml = read_yaml(PathBuf::from(maml_file))?;
-        let force = matches.get_flag("force");
-        if !force && check_for_maml_metadata(&file_path)? {
-            anyhow::bail!(
+    for file in files {
+        let file_path = PathBuf::from(file);
+        if !file_path.exists() {
+            anyhow::bail!("No file follows glob pattern '{}'", file_path.display());
+        }
+
+        if let Some(maml_file) = matches.get_one::<String>("insert-maml") {
+            let maml = read_yaml(PathBuf::from(maml_file))?;
+            let force = matches.get_flag("force");
+            if !force && check_for_maml_metadata(&file_path)? {
+                anyhow::bail!(
                 "{} already contains MAML metadata; pass -F to overwrite; run `dog -w {}` to view.",
                 file_path.display(),
                 file_path.display()
             );
-        }
-        write_waves_metadata(&file_path, &maml)?;
-        return Ok(());
-    }
-
-    let mut lazy_frame = read_file(file_path.clone())?;
-    let mut columns_selected = false;
-    let mut rows_selected = false;
-
-    // Optional column filtering BEFORE any printing
-    if let Some(columns) = matches.get_many::<String>("columns") {
-        let columns: Vec<Expr> = columns.map(col).collect();
-        lazy_frame = lazy_frame.select(columns);
-        columns_selected = true;
-    }
-
-    if let Some(filter_selection) = matches.get_one::<String>("filter") {
-        let polars_expresion = match parse_selection_string(filter_selection) {
-            Ok(expr) => expr,
-            _ => anyhow::bail!(
-                "Error parsing the filter selection string: {}",
-                filter_selection
-            ),
-        };
-        lazy_frame = lazy_frame.filter(polars_expresion);
-        rows_selected = true;
-    }
-
-    if let Some(outfile_name) = matches.get_one::<String>("outfile") {
-        if rows_selected | columns_selected {
-            write_parquet(&lazy_frame, &PathBuf::from(outfile_name))?;
-
+            }
+            write_waves_metadata(&file_path, &maml)?;
             return Ok(());
+        }
+
+        let mut lazy_frame = read_file(file_path.clone())?;
+        let mut columns_selected = false;
+        let mut rows_selected = false;
+
+        // Optional column filtering BEFORE any printing
+        if let Some(columns) = matches.get_many::<String>("columns") {
+            let columns: Vec<Expr> = columns.map(col).collect();
+            lazy_frame = lazy_frame.select(columns);
+            columns_selected = true;
+        }
+
+        if let Some(filter_selection) = matches.get_one::<String>("filter") {
+            let polars_expresion = match parse_selection_string(filter_selection) {
+                Ok(expr) => expr,
+                _ => anyhow::bail!(
+                    "Error parsing the filter selection string: {}",
+                    filter_selection
+                ),
+            };
+            lazy_frame = lazy_frame.filter(polars_expresion);
+            rows_selected = true;
+        }
+
+        if let Some(outfile_name) = matches.get_one::<String>("outfile") {
+            if rows_selected | columns_selected {
+                write_parquet(&lazy_frame, &PathBuf::from(outfile_name))?;
+
+                return Ok(());
+            } else {
+                anyhow::bail!("File not saved. No columns or rows have been selected.")
+            }
+        }
+
+        if *matches.get_one::<bool>("names").unwrap_or(&false) {
+            print_column_names(&mut lazy_frame)?;
+        } else if *matches.get_one::<bool>("data").unwrap_or(&false) {
+            print_only_data(lazy_frame, false)?;
+        } else if *matches.get_one::<bool>("tail").unwrap_or(&false) {
+            print_tail(lazy_frame)?;
+        } else if *matches.get_one::<bool>("head").unwrap_or(&false) {
+            print_head(&mut lazy_frame)?;
+        } else if *matches.get_one::<bool>("stats").unwrap_or(&false) {
+            print_stats(lazy_frame)?;
+        } else if *matches.get_one::<bool>("schema").unwrap_or(&false) {
+            print_schema(lazy_frame)?;
+        } else if *matches.get_one::<bool>("maml").unwrap_or(&false) {
+            print_waves_metadata(&file_path)?;
+        } else if *matches.get_one::<bool>("summary").unwrap_or(&false) {
+            print_summary(lazy_frame)?;
+        } else if *matches.get_one::<bool>("peak").unwrap_or(&false) {
+            peak(lazy_frame)?;
+        } else if *matches.get_one::<bool>("convert").unwrap_or(&false) {
+            let outfile = match which_file(&file_path)? {
+                FileType::Csv => PathBuf::from(file.replace(".csv", "_converted.parquet")),
+                FileType::Fits => PathBuf::from(file.replace(".fits", "_converted.parquet")),
+                FileType::Parquet => panic!("File is already a parquet!"),
+            };
+            write_parquet(&lazy_frame, &outfile).unwrap();
         } else {
-            anyhow::bail!("File not saved. No columns or rows have been selected.")
+            print_only_data(lazy_frame, true)?;
         }
     }
 
-    if *matches.get_one::<bool>("names").unwrap_or(&false) {
-        print_column_names(&mut lazy_frame)?;
-    } else if *matches.get_one::<bool>("data").unwrap_or(&false) {
-        print_only_data(lazy_frame, false)?;
-    } else if *matches.get_one::<bool>("tail").unwrap_or(&false) {
-        print_tail(lazy_frame)?;
-    } else if *matches.get_one::<bool>("head").unwrap_or(&false) {
-        print_head(&mut lazy_frame)?;
-    } else if *matches.get_one::<bool>("stats").unwrap_or(&false) {
-        print_stats(lazy_frame)?;
-    } else if *matches.get_one::<bool>("schema").unwrap_or(&false) {
-        print_schema(lazy_frame)?;
-    } else if *matches.get_one::<bool>("maml").unwrap_or(&false) {
-        print_waves_metadata(&file_path)?;
-    } else if *matches.get_one::<bool>("summary").unwrap_or(&false) {
-        print_summary(lazy_frame)?;
-    } else if *matches.get_one::<bool>("peak").unwrap_or(&false) {
-        peak(lazy_frame)?;
-    } else if *matches.get_one::<bool>("convert").unwrap_or(&false) {
-        let outfile = match which_file(&file_path)? {
-            FileType::Csv => PathBuf::from(file.replace(".csv", "_converted.parquet")),
-            FileType::Fits => PathBuf::from(file.replace(".fits", "_converted.parquet")),
-            FileType::Parquet => panic!("File is already a parquet!"),
-        };
-        write_parquet(&lazy_frame, &outfile).unwrap();
-    } else {
-        print_only_data(lazy_frame, true)?;
-    }
     Ok(())
 }
 


### PR DESCRIPTION
Closes #37

PR changes the arguments for files from 1 to at least 1. This means that glob patterns get fully resolved. 

Iterate over the multiple files that are parsed and repeat the same command for each one. 

Errors out if pattern can't find anything. 