### PR TITLE
58 adding list and delete for kw metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "dog-tsl"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dog-tsl"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 readme = "README.md"
 description = "A fast cli tool for viewing and handling parquet and other file formats."

--- a/README.md
+++ b/README.md
@@ -2,6 +2,30 @@
 
 ![Demo](.github/dog.gif)
 
+# Quick reference
+
+| Option | Arguments | Description |
+| --- | --- | --- |
+| *(none)* | | Prints the entire table with column names. |
+| `-d` `--data` | | Prints only the data, without the header. |
+| `-n` `--names` | | Prints only the column names. |
+| `-H` `--head` | `<N>` | Prints the top `<N>` rows of data and the column names. |
+| `-t` `--tail` | `<N>` | Prints the bottom `<N>` rows of data. |
+| `-c` `--columns` | `<COLUMN>` | Prints only the selected columns. Comma separated. |
+| `-f` `--filter` | `<SQL-STATEMENT>` | Selects rows with an sql-like statement. E.g. `'ra<10'`. |
+| `-o` `--outfile` | `<OUTFILE>` | Saves the current selection to `<OUTFILE>`. Requires `-c` or `-f`. |
+| `-s` `--summary` | | Prints the number of rows and columns and the first and last few values of each column. |
+| `-p` `--peak` | | Prints a small table in polars format. |
+| `--stats` | | Summary statistics for each column, depending on datatype. |
+| `--schema` | | Prints the metadata schema. |
+| `-k` `--keyword` | `<KEYWORD>` | Prints the `<KEYWORD>` metadata if it exists. |
+| `--list-keywords` | | Lists all keyword metadata in the file. |
+| `--insert-metadata` | `<METADATA-FILE> <KEYWORD>` | Inserts the contents of `<METADATA-FILE>` at the `<KEYWORD>` position. |
+| `--delete-keyword` | `<KEYWORD>` | Deletes the `<KEYWORD>` metadata if it exists. |
+| `-F` `--force` | | Overwrites existing keyword metadata. Only with `--insert-metadata`. |
+| `--convert` | | Converts a .csv or .fits file into a parquet. |
+
+All options take one or more files, so globs work: `dog -k maml *.parquet`.
 
 # Motivation
 Parquet is a relatively new, open source, file format from Apache which is becoming very popular and is already being adopted extensively within data intensive fields. It is a column-orientated format of storing data and benefits from a large amount of compression ([more information is available at the official apache parquet site](https://parquet.apache.org/)). 
@@ -224,34 +248,64 @@ The schema in the metadata of the parquet file can also be printed, but in this 
 dog --schema test_file.parquet
 ```
 
-### MAML metadata
-`dog` has specific support for "Meta YAML" or "MAML" (see: https://github.com/asgr/MAML). This is a structured metadata for astronomical surveys like [WAVES](https://wavesurvey.org/) and [4HS](https://4mosthemispheresurvey.github.io/). If this metadata exists then it can be viewed using the -w and --maml flags.
+### Keyword metadata
+Parquet files can store arbitrary key-value metadata in their footer, and `dog` can read, write, list, and delete these entries.
+
+`dog` has specific support for "Meta YAML" or "MAML" (see: https://github.com/asgr/MAML). This is a structured metadata for astronomical surveys like [WAVES](https://wavesurvey.org/) and [4HS](https://4mosthemispheresurvey.github.io/). If this metadata exists then it can be viewed with the `-k` `--keyword` flag by asking for the `maml` keyword.
 
 ```bash
-dog -w test_file.parquet
-dog --maml test_file.parquet
+dog -k maml test_file.parquet
 ```
 This is a useful way to strip MAML metadata from a parquet file
 ```bash
-dog -w test_file.parquet > test.maml
+dog -k maml test_file.parquet > test.maml
 ```
+The same flag works for any keyword, not just `maml`. If the keyword isn't in the file then nothing is printed and a warning is given.
 
-Users can also insert maml files directly into parquet files. Though consider if this is what you really want to do; usually this step would be done officially at some point and inserting the maml runs the risk of overwriting valid metadata and even corruption.
+#### Inserting metadata
+Users can insert the contents of any text file into a parquet file under a keyword of their choosing. Though consider if this is what you really want to do; usually this step would be done officially at some point and inserting metadata runs the risk of overwriting valid metadata and even corruption.
 
-Say we have a parquet file, "galaxies.parquet" that does not have any maml stored in it and we've built a maml file "galaxies_meta.maml". Then we can insert the "galaxies_meta.maml" contents into the parquet file:
-
-```
-dog --insert-maml galaxies_meta.maml galaxies.parquet
-```
-
-If the file already has a maml entry (like the above example does now) then you can forcefully overwrite it using the `-F` tag:
+The `--insert-metadata` flag takes the file to insert and the keyword to store it under, followed by the parquet file(s):
 
 ```
-dog -F --insert-maml different_galaxies_meta.maml galaxies.parquet
+dog --insert-metadata galaxies_meta.maml maml galaxies.parquet
+```
+
+Because the keyword is arbitrary, a file can hold as many entries as are useful. A markdown description of a table might go in alongside the maml:
+
+```
+dog --insert-metadata galaxies_description.md table_description galaxies.parquet
+```
+
+If the file already has an entry at that keyword (like the first example does now) then you can forcefully overwrite it using the `-F` tag:
+
+```
+dog -F --insert-metadata different_galaxies_meta.maml maml galaxies.parquet
 ```
 
 Else you will get an error.
 
+Multiple files can be given at once, which means globs work as expected. This will insert the same description into every parquet in the directory:
+
+```
+dog --insert-metadata survey_description.md rip_description *.parquet
+```
+
+#### Listing keywords
+To see which keywords a file actually has, use `--list-keywords`:
+
+```bash
+dog --list-keywords test_file.parquet
+```
+This prints every key in the file's key-value metadata, one per line. Note that this includes entries written by the tools that created the file (such as `ARROW:schema`) and not just those inserted by `dog`.
+
+#### Deleting a keyword
+A keyword and its contents can be removed with `--delete-keyword`:
+
+```bash
+dog --delete-keyword maml test_file.parquet
+```
+If the keyword isn't in the file then nothing is deleted and a warning is printed, so running this across a glob won't stop at the first file that happens to lack the keyword.
 
 
 ### Reading non-parquet and converting files

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,7 +84,7 @@ pub fn build_cli() -> Command {
         .arg(
             Arg::new("insert-metadata")
                 .long("insert-metadata")
-                .help("Inserts contents of a file a <METADATA-FILE> into the parquet file at a given <KEYWORD> header position.")
+                .help("Inserts contents of a <METADATA-FILE> into the parquet file at a given <KEYWORD> header position.")
                 .num_args(2)
                 .value_names(["METADATA-FILE", "KEYWORD"]),
         )
@@ -105,7 +105,7 @@ pub fn build_cli() -> Command {
         .arg(
             Arg::new("delete-kw-metadata")
             .long("delete-keyword")
-            .help("Deletes the fiven <KEYWORD> metadata from the header if it exists.")
+            .help("Deletes the given <KEYWORD> metadata from the header if it exists.")
             .num_args(1)
             .value_name("KEYWORD")
         )

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,3 @@
-// cli manager
-
 use clap::{Arg, ArgAction, ArgGroup, Command};
 
 pub fn build_cli() -> Command {
@@ -28,13 +26,6 @@ pub fn build_cli() -> Command {
                 .help("Prints only the data.")
                 .action(ArgAction::SetTrue)
                 .conflicts_with("names"),
-        )
-        .arg(
-            Arg::new("insert-metadata")
-                .long("insert-metadata")
-                .help("Inserts contents of a file a <METADATA-FILE> into the parquet file at a given <KEYWORD> header position.")
-                .num_args(2)
-                .value_names(["METADATA-FILE", "KEYWORD"]),
         )
         .arg(
             Arg::new("force")
@@ -91,12 +82,32 @@ pub fn build_cli() -> Command {
                 .action(ArgAction::SetTrue),
         )
         .arg(
+            Arg::new("insert-metadata")
+                .long("insert-metadata")
+                .help("Inserts contents of a file a <METADATA-FILE> into the parquet file at a given <KEYWORD> header position.")
+                .num_args(2)
+                .value_names(["METADATA-FILE", "KEYWORD"]),
+        )
+        .arg(
             Arg::new("keyword")
                 .short('k')
                 .long("keyword")
                 .help("Print the <KEYWORD> metadata if it exists.")
                 .num_args(1)
                 .value_name("KEYWORD")
+        )
+        .arg(
+            Arg::new("list-keyword-metadata")
+            .long("list-keyword")
+            .help("Lists the keyword metadata of the given parquet file")
+            .action(ArgAction::SetTrue)
+        )
+        .arg(
+            Arg::new("delete-keyword-metadata")
+            .long("delete-keyword")
+            .help("Deletes the fiven <KEYWORD> metadata from the header if it exists.")
+            .num_args(1)
+            .value_name("KEYWORD")
         )
         .arg(
             Arg::new("stats")
@@ -136,6 +147,8 @@ pub fn build_cli() -> Command {
                     "head",
                     "convert",
                     "insert-metadata",
+                    "delete-keyword-metadata",
+                    "list-keyword-metadata",
                     "summary",
                     "peak",
                     "stats",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,13 +97,13 @@ pub fn build_cli() -> Command {
                 .value_name("KEYWORD")
         )
         .arg(
-            Arg::new("list-keyword-metadata")
-            .long("list-keyword")
+            Arg::new("list-kw-metadata")
+            .long("list-keywords")
             .help("Lists the keyword metadata of the given parquet file")
             .action(ArgAction::SetTrue)
         )
         .arg(
-            Arg::new("delete-keyword-metadata")
+            Arg::new("delete-kw-metadata")
             .long("delete-keyword")
             .help("Deletes the fiven <KEYWORD> metadata from the header if it exists.")
             .num_args(1)
@@ -147,8 +147,8 @@ pub fn build_cli() -> Command {
                     "head",
                     "convert",
                     "insert-metadata",
-                    "delete-keyword-metadata",
-                    "list-keyword-metadata",
+                    "delete-kw-metadata",
+                    "list-kw-metadata",
                     "summary",
                     "peak",
                     "stats",

--- a/src/footer.rs
+++ b/src/footer.rs
@@ -60,7 +60,7 @@ impl TryFrom<u8> for ThriftID {
 
 /// Insert/replace the `maml` key in `output_path`'s footer, in place.
 /// This is the custom waves maml function. But we could upsert to be generalized in the future
-pub fn write_waves_metadata(
+pub fn write_keyword_metadata(
     output_path: &PathBuf,
     file_contents: &str,
     keyword: &str,
@@ -156,6 +156,92 @@ fn upsert_kv(metadata_blob: &[u8], key: &str, value: &str) -> Result<Vec<u8>> {
 
         skip_value(metadata_blob, &mut pos, type_id)?;
     }
+}
+
+/// Walk the top-level `FileMetaData` fields and rebuilds, ignoring `key`
+fn delete_kv(metadata_blob: &[u8], key: &str) -> Result<Vec<u8>> {
+    let mut pos = 0usize;
+    let mut last_id = 0i64;
+
+    loop {
+        let field_start = pos;
+        let (type_id, field_id) = read_field_header(metadata_blob, &mut pos, &mut last_id)?;
+
+        if let ThriftID::Stop = type_id {
+            bail!("No keyword metadata. Nothing to delete.")
+        }
+
+        if field_id == KEY_VALUE_FIELD_ID {
+            if type_id != ThriftID::List {
+                bail!("key_value_metadata is not a list (thrift type {type_id:?})");
+            }
+            let (elem_type, count) = read_collection_header(metadata_blob, &mut pos)?;
+            if count > 0 && elem_type != ThriftID::Struct {
+                bail!("key_value_metadata elements are not structs");
+            }
+            let mut pairs = Vec::with_capacity(usize::try_from(count)? + 1);
+            for _ in 0..count {
+                pairs.push(parse_key_value(metadata_blob, &mut pos)?);
+            }
+            let list_end = pos; // first byte after the list = next field header
+
+            pairs.retain(|(k, _)| k != key);
+
+            let field = encode_kv_field(&pairs);
+            let mut out = Vec::with_capacity(metadata_blob.len() + field.len());
+            out.extend_from_slice(&metadata_blob[..field_start]); // fields before field 5
+            out.extend_from_slice(&field); // freshly encoded field 5 (long-form header)
+            out.extend_from_slice(&metadata_blob[list_end..]); // fields after field 5 + STOP
+            return Ok(out);
+        }
+
+        skip_value(metadata_blob, &mut pos, type_id)?;
+    }
+}
+
+pub fn delete_keyword_metadata(output_path: &PathBuf, keyword: &str) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(output_path)?;
+    let file_len = file.metadata()?.len();
+    if file_len < 12 {
+        bail!(
+            "{}: not a parquet file (smaller than 12 bytes)",
+            output_path.display()
+        );
+    }
+
+    // Last 8 bytes: [metadata_len u32 LE][PAR1].
+    let mut tail = [0u8; 8];
+    file.seek(SeekFrom::End(-8))?;
+    file.read_exact(&mut tail)?;
+    if &tail[4..] != MAGIC {
+        bail!(
+            "{}: missing PAR1 footer magic (encrypted or non-parquet?)",
+            output_path.display()
+        );
+    }
+    let metadata_len = u64::from(u32::from_le_bytes(tail[..4].try_into().unwrap()));
+    let footer_start = file_len
+        .checked_sub(8 + metadata_len)
+        .ok_or_else(|| anyhow!("declared footer length exceeds file size"))?;
+
+    let mut blob = vec![0u8; usize::try_from(metadata_len)?];
+    file.seek(SeekFrom::Start(footer_start))?;
+    file.read_exact(&mut blob)?;
+    let new_blob = delete_kv(&blob, keyword)?;
+
+    // Overwrite only the tail, starting exactly where the old footer began.
+    file.seek(SeekFrom::Start(footer_start))?;
+    file.write_all(&new_blob)?;
+    file.write_all(&(u32::try_from(new_blob.len())?).to_le_bytes())?;
+    file.write_all(MAGIC)?;
+
+    // The new footer may be shorter or longer than the old one; set exact length.
+    file.set_len(footer_start + new_blob.len() as u64 + 8)?;
+    file.sync_all()?;
+    Ok(())
 }
 
 /// Encode a complete `FileMetaData` field 5 from pairs. Uses the long-form

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,13 @@ fn handle_arguments(matches: ArgMatches) -> Result<()> {
         .get_many::<String>("file")
         .expect("File argument missing");
 
+    if files.len() > 1 && matches.contains_id("outfile") {
+        bail!(
+            "--outfile takes a single input file; {} were given.",
+            files.len()
+        );
+    }
+
     for file in files {
         let file_path = PathBuf::from(file);
         if !file_path.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod write;
 use std::path::PathBuf;
 
 use crate::filter::parse_selection_string;
-use crate::footer::write_waves_metadata;
+use crate::footer::{delete_keyword_metadata, write_keyword_metadata};
 use crate::printer::*;
 use crate::reader::{read_file, which_file, FileType};
 use crate::write::write_parquet;
@@ -46,7 +46,21 @@ fn handle_arguments(matches: ArgMatches) -> Result<()> {
                 file_path.display()
             );
             }
-            write_waves_metadata(&file_path, &maml, &keyword)?;
+            write_keyword_metadata(&file_path, &maml, &keyword)?;
+            continue;
+        }
+
+        if let Some(keyword) = matches.get_one::<String>("delete-kw-metadata") {
+            if !check_for_keyword_metadata(&file_path, keyword)? {
+                eprintln!(
+                    "File name '{}' does not have a keyword '{}' in it's metadata. run `dog --list-keywords {}` to list current keywords",
+                    file_path.display(),
+                    keyword,
+                    file_path.display(),
+                )
+            } else {
+                delete_keyword_metadata(&file_path, keyword)?;
+            }
             continue;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,14 +32,14 @@ fn handle_arguments(matches: ArgMatches) -> Result<()> {
             let meta_file = PathBuf::from(arguments.next().unwrap());
             let keyword = arguments.next().unwrap();
             if !meta_file.exists() {
-                bail!("meta file '{}' does not exist", meta_file.display());
+                bail!("The file: '{}', does not exist", meta_file.display());
             }
 
             let maml = std::fs::read_to_string(meta_file)?;
             let force = matches.get_flag("force");
             if !force && check_for_keyword_metadata(&file_path, &keyword)? {
                 bail!(
-                "{} already contains '{}' keyword-metadata; pass -F to overwrite; run `dog -w {} {}` to view.",
+                "The file: '{}', already contains the keyword: '{}'!; pass -F to overwrite; run `dog -w {} {}` to view.",
                 file_path.display(),
                 keyword,
                 keyword,
@@ -53,7 +53,7 @@ fn handle_arguments(matches: ArgMatches) -> Result<()> {
         if let Some(keyword) = matches.get_one::<String>("delete-kw-metadata") {
             if !check_for_keyword_metadata(&file_path, keyword)? {
                 eprintln!(
-                    "File name '{}' does not have a keyword '{}' in it's metadata. run `dog --list-keywords {}` to list current keywords",
+                    "The file: '{}', does not have the keyword: '{}', in it's metadata. Run `dog --list-keywords {}` to list current keywords",
                     file_path.display(),
                     keyword,
                     file_path.display(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,8 @@ fn handle_arguments(matches: ArgMatches) -> Result<()> {
             print_summary(lazy_frame)?;
         } else if matches.get_flag("peak") {
             peak(lazy_frame)?;
+        } else if matches.get_flag("list-kw-metadata") {
+            list_keyword_metadata(&file_path)?;
         } else if matches.get_flag("convert") {
             let outfile = match which_file(&file_path)? {
                 FileType::Csv => PathBuf::from(file.replace(".csv", "_converted.parquet")),

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -37,6 +37,20 @@ pub fn check_for_keyword_metadata(file_name: &PathBuf, keyword: &str) -> Result<
     Ok(false)
 }
 
+pub fn list_keyword_metadata(file_name: &PathBuf) -> Result<()> {
+    let file = File::open(file_name)?;
+    let mut reader = ParquetReader::new(file);
+    let kv_metadata = reader
+        .get_metadata()?
+        .key_value_metadata()
+        .as_ref()
+        .unwrap();
+    for key in kv_metadata {
+        println!("{}", key.key.bold().magenta());
+    }
+    Ok(())
+}
+
 pub fn print_keyword_metadata(file_name: &PathBuf, keyword: &str) -> Result<()> {
     let file = File::open(file_name)?;
     let mut reader = ParquetReader::new(file);

--- a/tests/footer.rs
+++ b/tests/footer.rs
@@ -1,4 +1,5 @@
 use assert_cmd::Command;
+use predicates::prelude::*;
 use std::{fs, path::PathBuf};
 use tempfile::{tempdir, TempDir};
 
@@ -7,11 +8,67 @@ fn copy_test_files() -> (TempDir, PathBuf, PathBuf) {
     let dir = tempdir().expect("create temp dir");
     let parquet_path = dir.path().join("test.parquet");
     let maml_path = dir.path().join("test.maml");
-
     fs::copy("tests/fixtures/test.maml", &maml_path).expect("failed to copy maml file to temp dir");
     fs::copy("tests/fixtures/test.parquet", &parquet_path)
         .expect("failed to copy parquet file to temp dir");
     (dir, parquet_path, maml_path)
+}
+
+/// Copies the markdown fixture in alongside the standard test bed.
+fn copy_markdown(dir: &TempDir) -> PathBuf {
+    let markdown = dir.path().join("test.md");
+    fs::copy("tests/fixtures/test.md", &markdown).expect("Failed to copy test.md file.");
+    markdown
+}
+
+/// Returns stdout of a successful `dog` invocation as a String.
+fn stdout_of(args: &[&str]) -> String {
+    let output = Command::cargo_bin("dog")
+        .unwrap()
+        .env("NO_COLOR", "1")
+        .args(args)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    String::from_utf8(output).expect("stdout was not utf8")
+}
+
+/// True if `keyword` appears as its own line in `--list-keywords` output.
+fn lists_keyword(listed: &str, keyword: &str) -> bool {
+    listed.lines().any(|l| l.trim() == keyword)
+}
+
+/// `dog -p <file>` should always work on a non-corrupt parquet.
+fn assert_not_corrupted(parquet: &PathBuf) {
+    Command::cargo_bin("dog")
+        .unwrap()
+        .arg("-p")
+        .arg(parquet)
+        .assert()
+        .success();
+}
+
+fn insert(meta: &PathBuf, keyword: &str, parquet: &PathBuf) {
+    Command::cargo_bin("dog")
+        .unwrap()
+        .arg("--insert-metadata")
+        .arg(meta)
+        .arg(keyword)
+        .arg(parquet)
+        .assert()
+        .success();
+}
+
+fn delete(keyword: &str, parquet: &PathBuf) {
+    Command::cargo_bin("dog")
+        .unwrap()
+        .arg("--delete-keyword")
+        .arg(keyword)
+        .arg(parquet)
+        .assert()
+        .success();
 }
 
 #[test]
@@ -45,6 +102,7 @@ fn markdown() {
 #[test]
 fn no_maml_exist() {
     let (_dir, parquet, maml) = copy_test_files();
+
     let mut cmd = Command::cargo_bin("dog").unwrap();
     cmd.arg("--insert-metadata")
         .arg(&maml)
@@ -60,6 +118,7 @@ fn no_maml_exist() {
 #[test]
 fn maml_exists_without_force_fails() {
     let (_dir, parquet, maml) = copy_test_files();
+
     let mut cmd = Command::cargo_bin("dog").unwrap();
     cmd.arg("--insert-metadata")
         .arg(&maml)
@@ -80,6 +139,7 @@ fn maml_exists_without_force_fails() {
 #[test]
 fn maml_exists_with_force() {
     let (_dir, parquet, maml) = copy_test_files();
+
     let mut cmd = Command::cargo_bin("dog").unwrap();
     cmd.arg("--insert-metadata")
         .arg(&maml)
@@ -99,4 +159,135 @@ fn maml_exists_with_force() {
 
     let mut cmd = Command::cargo_bin("dog").unwrap();
     cmd.arg(&parquet).assert().success(); // check file isn't corrupted
+}
+
+#[test]
+fn list_keywords_shows_inserted_keyword() {
+    let (_dir, parquet, maml) = copy_test_files();
+    insert(&maml, "maml", &parquet);
+
+    let listed = stdout_of(&["--list-keywords", parquet.to_str().unwrap()]);
+    assert!(
+        lists_keyword(&listed, "maml"),
+        "expected 'maml' in --list-keywords output, got:\n{listed}"
+    );
+}
+
+#[test]
+fn list_keywords_shows_all_inserted_keywords() {
+    let (dir, parquet, maml) = copy_test_files();
+    let markdown = copy_markdown(&dir);
+
+    insert(&maml, "maml", &parquet);
+    insert(&markdown, "markdown", &parquet);
+
+    let listed = stdout_of(&["--list-keywords", parquet.to_str().unwrap()]);
+    assert!(lists_keyword(&listed, "maml"), "missing 'maml':\n{listed}");
+    assert!(
+        lists_keyword(&listed, "markdown"),
+        "missing 'markdown':\n{listed}"
+    );
+}
+
+#[test]
+fn round_trip_insert_list_delete_list() {
+    let (dir, parquet, maml) = copy_test_files();
+    let markdown = copy_markdown(&dir);
+
+    insert(&maml, "maml", &parquet);
+    insert(&markdown, "markdown", &parquet);
+
+    let before = stdout_of(&["--list-keywords", parquet.to_str().unwrap()]);
+    assert!(lists_keyword(&before, "maml"), "missing 'maml':\n{before}");
+    assert!(
+        lists_keyword(&before, "markdown"),
+        "missing 'markdown':\n{before}"
+    );
+
+    delete("maml", &parquet);
+
+    let after = stdout_of(&["--list-keywords", parquet.to_str().unwrap()]);
+    assert!(
+        !lists_keyword(&after, "maml"),
+        "'maml' still listed after delete:\n{after}"
+    );
+    assert!(
+        lists_keyword(&after, "markdown"),
+        "delete of 'maml' also removed 'markdown':\n{after}"
+    );
+
+    // the deleted keyword should no longer be retrievable
+    let got = stdout_of(&["-k", "maml", parquet.to_str().unwrap()]);
+    assert!(
+        got.trim().is_empty(),
+        "-k maml returned content after delete:\n{got}"
+    );
+
+    // the surviving keyword should be untouched
+    let expected = fs::read_to_string(&markdown).unwrap();
+    let got = stdout_of(&["-k", "markdown", parquet.to_str().unwrap()]);
+    assert_eq!(got.trim_end(), expected.trim_end());
+
+    assert_not_corrupted(&parquet);
+}
+
+#[test]
+fn delete_then_reinsert_without_force_succeeds() {
+    let (_dir, parquet, maml) = copy_test_files();
+    insert(&maml, "maml", &parquet);
+    delete("maml", &parquet);
+
+    // the key is gone, so a plain insert should not trip the -F guard
+    insert(&maml, "maml", &parquet);
+
+    let expected = fs::read_to_string(&maml).unwrap();
+    let got = stdout_of(&["-k", "maml", parquet.to_str().unwrap()]);
+    assert_eq!(got.trim_end(), expected.trim_end());
+    assert_not_corrupted(&parquet);
+}
+
+#[test]
+fn delete_missing_keyword_warns_but_succeeds() {
+    let (_dir, parquet, _maml) = copy_test_files();
+
+    Command::cargo_bin("dog")
+        .unwrap()
+        .env("NO_COLOR", "1")
+        .arg("--delete-keyword")
+        .arg("not_a_real_keyword")
+        .arg(&parquet)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("not_a_real_keyword"));
+
+    assert_not_corrupted(&parquet);
+}
+
+#[test]
+fn delete_all_inserted_keywords_leaves_readable_file() {
+    let (dir, parquet, maml) = copy_test_files();
+    let markdown = copy_markdown(&dir);
+
+    insert(&maml, "maml", &parquet);
+    insert(&markdown, "markdown", &parquet);
+
+    delete("maml", &parquet);
+    delete("markdown", &parquet);
+
+    let listed = stdout_of(&["--list-keywords", parquet.to_str().unwrap()]);
+    assert!(
+        !lists_keyword(&listed, "maml"),
+        "'maml' survived:\n{listed}"
+    );
+    assert!(
+        !lists_keyword(&listed, "markdown"),
+        "'markdown' survived:\n{listed}"
+    );
+
+    assert_not_corrupted(&parquet);
+    Command::cargo_bin("dog")
+        .unwrap()
+        .arg(&parquet)
+        .assert()
+        .success();
 }

--- a/tests/globbing.rs
+++ b/tests/globbing.rs
@@ -44,6 +44,66 @@ fn assert_keyword_matches(parquet: &PathBuf, keyword: &str, expected_file: &Path
     );
 }
 
+/// Returns stdout of a successful `dog` invocation as a String.
+fn stdout_of(args: &[&str]) -> String {
+    let output = Command::cargo_bin("dog")
+        .unwrap()
+        .env("NO_COLOR", "1")
+        .args(args)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    String::from_utf8(output).expect("stdout was not utf8")
+}
+
+/// True if `keyword` appears as its own line in `--list-keywords` output.
+fn lists_keyword(listed: &str, keyword: &str) -> bool {
+    listed.lines().any(|l| l.trim() == keyword)
+}
+
+/// `dog -p <file>` should always work on a non-corrupt parquet.
+fn assert_not_corrupted(parquet: &PathBuf) {
+    Command::cargo_bin("dog")
+        .unwrap()
+        .arg("-p")
+        .arg(parquet)
+        .assert()
+        .success();
+}
+
+/// Runs `dog <args...> <p1> <p2> ...` over every parquet in one invocation.
+fn run_over_all(args: &[&str], parquets: &[PathBuf]) -> assert_cmd::assert::Assert {
+    let mut cmd = Command::cargo_bin("dog").unwrap();
+    cmd.env("NO_COLOR", "1").args(args);
+    for p in parquets {
+        cmd.arg(p);
+    }
+    cmd.assert()
+}
+
+/// Inserts `keyword` into a single parquet.
+fn insert(meta: &PathBuf, keyword: &str, parquet: &PathBuf) {
+    Command::cargo_bin("dog")
+        .unwrap()
+        .arg("--insert-metadata")
+        .arg(meta)
+        .arg(keyword)
+        .arg(parquet)
+        .assert()
+        .success();
+}
+
+/// Inserts `keyword` into every parquet in one invocation.
+fn insert_over_all(meta: &PathBuf, keyword: &str, parquets: &[PathBuf]) {
+    run_over_all(
+        &["--insert-metadata", meta.to_str().unwrap(), keyword],
+        parquets,
+    )
+    .success();
+}
+
 #[test]
 fn glob_insert_maml_all_files() {
     let (_dir, parquets, maml) = copy_globbed_files(3);
@@ -147,5 +207,145 @@ fn glob_multiple_keywords_coexist() {
     for p in &parquets {
         assert_keyword_matches(p, "maml", &maml);
         assert_keyword_matches(p, "markdown", &markdown_path);
+    }
+}
+
+#[test]
+fn glob_list_keywords_covers_every_file() {
+    let (_dir, parquets, maml) = copy_globbed_files(3);
+    insert_over_all(&maml, "maml", &parquets);
+
+    // one invocation across all files should not blow up
+    run_over_all(&["--list-keywords"], &parquets).success();
+
+    // and each file individually should show the key
+    for p in &parquets {
+        let listed = stdout_of(&["--list-keywords", p.to_str().unwrap()]);
+        assert!(
+            lists_keyword(&listed, "maml"),
+            "'maml' missing from {}:\n{listed}",
+            p.display()
+        );
+    }
+}
+
+#[test]
+fn glob_delete_keyword_removes_from_every_file() {
+    let (_dir, parquets, maml) = copy_globbed_files(3);
+    insert_over_all(&maml, "maml", &parquets);
+
+    run_over_all(&["--delete-keyword", "maml"], &parquets).success();
+
+    for p in &parquets {
+        let listed = stdout_of(&["--list-keywords", p.to_str().unwrap()]);
+        assert!(
+            !lists_keyword(&listed, "maml"),
+            "'maml' survived delete in {}:\n{listed}",
+            p.display()
+        );
+        assert_not_corrupted(p);
+    }
+}
+
+#[test]
+fn glob_delete_missing_keyword_does_not_stop_the_run() {
+    let (_dir, parquets, maml) = copy_globbed_files(3);
+
+    // only the middle file gets the keyword
+    insert(&maml, "maml", &parquets[1]);
+
+    // deleting across the whole glob should warn on 1 and 3 but still do 2
+    run_over_all(&["--delete-keyword", "maml"], &parquets).success();
+
+    for p in &parquets {
+        let listed = stdout_of(&["--list-keywords", p.to_str().unwrap()]);
+        assert!(
+            !lists_keyword(&listed, "maml"),
+            "'maml' survived delete in {}:\n{listed}",
+            p.display()
+        );
+        assert_not_corrupted(p);
+    }
+}
+
+#[test]
+fn glob_get_keyword_missing_from_some_files_does_not_stop_the_run() {
+    let (_dir, parquets, maml) = copy_globbed_files(3);
+
+    // only the last file gets the keyword
+    insert(&maml, "maml", &parquets[2]);
+
+    // -k across the glob should skip the misses and still print the hit
+    let got = stdout_of(&[
+        "-k",
+        "maml",
+        parquets[0].to_str().unwrap(),
+        parquets[1].to_str().unwrap(),
+        parquets[2].to_str().unwrap(),
+    ]);
+    let expected = fs::read_to_string(&maml).unwrap();
+    assert_eq!(
+        got.trim_end(),
+        expected.trim_end(),
+        "-k over a partially-tagged glob did not return the one hit"
+    );
+
+    for p in &parquets {
+        assert_not_corrupted(p);
+    }
+}
+
+#[test]
+fn glob_delete_one_keyword_leaves_others_intact() {
+    let (dir, parquets, maml) = copy_globbed_files(3);
+    let markdown_path = dir.path().join("test.md");
+    fs::copy("tests/fixtures/test.md", &markdown_path).expect("Failed to copy test.md file.");
+
+    insert_over_all(&maml, "maml", &parquets);
+    insert_over_all(&markdown_path, "markdown", &parquets);
+
+    run_over_all(&["--delete-keyword", "maml"], &parquets).success();
+
+    for p in &parquets {
+        let listed = stdout_of(&["--list-keywords", p.to_str().unwrap()]);
+        assert!(
+            !lists_keyword(&listed, "maml"),
+            "'maml' survived in {}:\n{listed}",
+            p.display()
+        );
+        assert!(
+            lists_keyword(&listed, "markdown"),
+            "deleting 'maml' also removed 'markdown' from {}:\n{listed}",
+            p.display()
+        );
+        assert_keyword_matches(p, "markdown", &markdown_path);
+        assert_not_corrupted(p);
+    }
+}
+
+#[test]
+fn glob_round_trip_insert_list_delete_list() {
+    let (_dir, parquets, maml) = copy_globbed_files(3);
+
+    insert_over_all(&maml, "maml", &parquets);
+    for p in &parquets {
+        let listed = stdout_of(&["--list-keywords", p.to_str().unwrap()]);
+        assert!(lists_keyword(&listed, "maml"), "{}:\n{listed}", p.display());
+    }
+
+    run_over_all(&["--delete-keyword", "maml"], &parquets).success();
+    for p in &parquets {
+        let listed = stdout_of(&["--list-keywords", p.to_str().unwrap()]);
+        assert!(
+            !lists_keyword(&listed, "maml"),
+            "{}:\n{listed}",
+            p.display()
+        );
+    }
+
+    // and the files still read fine after the round trip
+    for p in &parquets {
+        assert_not_corrupted(p);
+        Command::cargo_bin("dog").unwrap().arg(p).assert().success();
     }
 }


### PR DESCRIPTION
Closes #58
Closes #59

Adds list-keywords to list all the keyword metadata that exists in the paruqet file
Adds delete-keyword which allows the user to delte a keyword metadata item
Updates README with a summary table of commands right away. 
Adds new functions to README and replaces old maml command with the new -k one. 

Grammer fixes and more integration tests too. 